### PR TITLE
Fix go.mod version format for older Go toolchains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/glundgren93/sl-cli
 
-go 1.25.0
+go 1.25
 
 require (
 	github.com/fatih/color v1.18.0 // indirect


### PR DESCRIPTION
## Summary
- Change `go` directive in `go.mod` from `1.25.0` to `1.25`
- The three-part version (`MAJOR.MINOR.PATCH`) is invalid for the `go` directive and causes build failures on older Go toolchains (e.g., Raspberry Pi 4)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Fixes #1